### PR TITLE
fix: use SequentialSampler for correct loss computation in USP mode

### DIFF
--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -375,7 +375,9 @@ class CustomDPOTrainer(DPOTrainer):
 
     @override
     def _get_train_sampler(self):
-        if self.model.sequence_parallel_group is not None:
+        # Use SequentialSampler for all SP modes (ZigZag-Ring/Ulysses/USP)
+        # to ensure all ranks process the same batch (different parts of the sequence)
+        if self.model.sequence_parallel_group is not None or self.model.sp_ulysses_group is not None:
             return SequentialSampler(self.train_dataset)
         else:
             return super()._get_train_sampler()

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -98,7 +98,9 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
 
     @override
     def _get_train_sampler(self):
-        if self.model.sequence_parallel_group is not None:
+        # Use SequentialSampler for all SP modes (ZigZag-Ring/Ulysses/USP)
+        # to ensure all ranks process the same batch (different parts of the sequence)
+        if self.model.sequence_parallel_group is not None or self.model.sp_ulysses_group is not None:
             return SequentialSampler(self.train_dataset)
         else:
             return super()._get_train_sampler()


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

## issue

- 问题描述：USP mode下loss计算异常。sft/dpo微调的loss数值波动大（loss: 6~10）且中间step出现loss为0的情况；
- 根因定位：USP模式下没有使用SequentialSampler来保证每个rank拿到相同批次的数据（不同序列切片），而使用了DP的Sampler使得每个rank拿到了不同的批次导致计算不符合预期
- 解决方法：当前PR可修复上述问题